### PR TITLE
[WIP] Adding permission middleware on BE APIs and sending ID JWT tokens from FE to all user oriented APIs

### DIFF
--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -1,0 +1,33 @@
+from flask import request, jsonify, g
+from functools import wraps
+from firebase_admin import auth
+
+
+# Middleware function to verify Firebase ID token
+def firebase_token_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        id_token = request.headers.get('Authorization')
+
+        if not id_token:
+            return jsonify({'message': 'Token is missing'}), 401
+
+        try:
+            # Verify the Firebase ID token
+            decoded_token = auth.verify_id_token(id_token)
+            uid = decoded_token['uid']
+            # You can fetch additional user information if needed
+            user = auth.get_user(uid)
+
+            # Store user information in Flask's global 'g' object if necessary
+            g.user = user
+
+            return f(*args, **kwargs)
+
+        # except auth.AuthError as e:
+        #     return jsonify({'message': 'Token verification failed', 'error': str(e)}), 401
+
+        except Exception as e:
+            return jsonify({'message': 'Token verification failed', 'error': str(e)}), 401
+
+    return decorated_function

--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -1,15 +1,17 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, g
 from bson.objectid import ObjectId
 from config import db
 import os
 from pymongo import ReturnDocument, DESCENDING, ASCENDING
+from middleware import firebase_token_required
 
 ui = Blueprint("ui", __name__)
 webserver = os.getenv('WEBSERVER')
 
 @ui.route('/api/tasks', methods=['GET'])
+@firebase_token_required
 def getTasks():
-    uid = request.args.get('uid')
+    uid = g.user.uid
     print('getTasks::uid: ', uid)
 
     collection = db['verticals']

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18435,16 +18435,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -32832,9 +32832,9 @@
       }
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true
     },
     "unbox-primitive": {

--- a/frontend/src/components/LogIn.js
+++ b/frontend/src/components/LogIn.js
@@ -29,10 +29,11 @@ const LogIn = ({ setEmail_ }) => {
 
     // const auth = getAuth();
     await signInWithEmailAndPassword(auth, email, password)
-    .then((userCredential) => {
+    .then(async (userCredential) => {
       // Signed in 
-      // const user = userCredential.user;
-      // console.log("User: ", user)
+      const user = userCredential.user;
+      const idToken = await user.getIdToken(true)
+      localStorage.setItem('firebaseToken', idToken);
       navigate("/")
     })
     .catch((error) => {

--- a/frontend/src/components/Tasks.js
+++ b/frontend/src/components/Tasks.js
@@ -23,11 +23,11 @@ const Tasks = () => {
 
     useEffect(() => {
         //check if admin
-        auth.currentUser.getIdTokenResult()
+        user.getIdTokenResult()
         .then((idTokenResult) => {
           if (!!idTokenResult.claims.admin) {
             setAdmin(true)
-          } 
+          }
         })
         .catch((error) => {
           console.log(error);
@@ -37,9 +37,15 @@ const Tasks = () => {
     }, [])
 
     const fetchTasks = async () => {
-      const res = await fetch(process.env.REACT_APP_FLASK_WEBSERVER + 'tasks?uid=' + user.uid)
+      const res = await fetch(`${process.env.REACT_APP_FLASK_WEBSERVER}tasks`, {
+        method: 'GET',
+        headers: {
+          'Authorization': `${localStorage.getItem('firebaseToken')}`,
+          'Content-Type': 'application/json'
+        }
+      });
       const data = await res.json()
-      data.reverse()      
+      data.reverse()
       setTasks(data)
       setLoading(false)
       setPolling(data.some(task => task.status === 'Pending'))


### PR DESCRIPTION
Note: Only added logic for the Task fetching logic (FE and BE). Will apply to all relevant places once approach is final

Questions:

- Is storing token on localStorage after login from webApp the best approach?
- Will this token require further upkeep -> i.e refresh token, remove on sign out
- [NOT NEEDED] Figure out if "Login via Google" works and if that user flow also similarly needs to save the token on localStorage


TODO:
remove token on sign out